### PR TITLE
StepCounter: add a reset argument (default True) at retrieval

### DIFF
--- a/src/gshock_api/gshock_api.py
+++ b/src/gshock_api/gshock_api.py
@@ -97,9 +97,9 @@ class GshockAPI:
         """Gets the daily step count total for step counter supported watches."""
         return await watch_info.protocol.get_step_count_today(self.connection)
 
-    async def get_step_count(self) -> StepCounterData:
+    async def get_step_count(self, reset: bool = True) -> StepCounterData:
         """Gets complete step counter data (hourly and daily history)."""
-        return await watch_info.protocol.get_step_count(self.connection)
+        return await watch_info.protocol.get_step_count(self.connection, reset)
 
     async def get_reminders(self) -> list[Any]:
         """Gets the current events (reminders) from the watch."""

--- a/src/gshock_api/iolib/step_counter_io.py
+++ b/src/gshock_api/iolib/step_counter_io.py
@@ -69,9 +69,11 @@ class StepCounterIO:
     connection: ConnectionProtocol | None = None
     accumulator: bytearray = bytearray()
     expected_length: int = FALLBACK_EXPECTED_LENGTH
+    reset: bool = True
 
     @staticmethod
-    async def request(connection: ConnectionProtocol) -> StepCounterData:
+    async def request(connection: ConnectionProtocol, reset: bool = False) -> StepCounterData:
+        """Request steps counter data from the watch and optionally reset them"""
         from gshock_api.watch_info import watch_info
 
         if not watch_info.hasStepCounter:
@@ -79,6 +81,7 @@ class StepCounterIO:
             return StepCounterData.unavailable()
 
         StepCounterIO.connection = connection
+        StepCounterIO.reset = reset
         StepCounterIO.accumulator = bytearray()
         StepCounterIO.expected_length = FALLBACK_EXPECTED_LENGTH
         StepCounterIO.result = CancelableResult[StepCounterData]()
@@ -109,7 +112,7 @@ class StepCounterIO:
 
     @staticmethod
     def on_received(data: bytes) -> None:
-        """Accumulates incoming fragments and parses StepCounterData when full payload is received."""
+        """Accumulates incoming fragments and parses StepCounterData when full payload is received. Acknowledge the transaction if `reset` was passed earlier so the watch reset the counters."""
         if StepCounterIO.result is None:
             return
 
@@ -122,8 +125,8 @@ class StepCounterIO:
         if len(StepCounterIO.accumulator) < StepCounterIO.expected_length:
             return
 
-        # Acknowledge end of transaction
-        if StepCounterIO.connection is not None:
+        # Acknowledge end of transaction if reset was requested
+        if StepCounterIO.connection is not None and StepCounterIO.reset:
             try:
                 # Fire-and-forget end transaction command
                 import asyncio

--- a/src/gshock_api/protocols/standard_protocol.py
+++ b/src/gshock_api/protocols/standard_protocol.py
@@ -192,9 +192,9 @@ class StandardProtocol(WatchProtocol):
         data = await StepCounterIO.request(connection)
         return data.current_day_steps if data.current_day_steps is not None else 0
 
-    async def get_step_count(self, connection: Any) -> Any:
+    async def get_step_count(self, connection: Any, reset: bool = True) -> Any:
         from gshock_api.iolib.step_counter_io import StepCounterIO
-        return await StepCounterIO.request(connection)
+        return await StepCounterIO.request(connection, reset)
 
     async def get_event_from_watch(self, connection: Any, event_number: int) -> Any:
         from gshock_api import message_dispatcher

--- a/src/gshock_api/protocols/watch_protocol.py
+++ b/src/gshock_api/protocols/watch_protocol.py
@@ -144,7 +144,7 @@ class WatchProtocol(ABC):
         pass
 
     @abstractmethod
-    async def get_step_count(self, connection: Any) -> Any:
+    async def get_step_count(self, connection: Any, reset: bool) -> Any:
         """Gets complete step counter data from the watch."""
         pass
 


### PR DESCRIPTION
Acknowledging the steps data transaction makes the watch reset the counters

As requested in #3 here's a PR adding a `reset` argument to the StepsCounterIO functions. I've set it to default to `True` since it seems to be the default behavior and I guess it's usually a good idea to do it.

I'd welcome @taviso and @f3z comments on this.