### PR TITLE
make BLE connection timeout tunable

### DIFF
--- a/src/gshock_api/connection.py
+++ b/src/gshock_api/connection.py
@@ -44,7 +44,7 @@ class Connection:
             for char in service.characteristics:
                 self.characteristics_map[char.uuid] = char.uuid
 
-    async def connect(self, watch_filter: WatchFilter = None) -> bool:
+    async def connect(self, watch_filter: WatchFilter = None, timeout: float = 30) -> bool:
         """Connects to the G-Shock watch, optionally scanning if no address is provided."""
         try:
             if self.address is None:
@@ -61,7 +61,7 @@ class Connection:
             if self.address is None:
                 return False
 
-            self.client = BleakClient(self.address)
+            self.client = BleakClient(self.address, timeout=timeout)
             await self.client.connect()
 
             if not self.client.is_connected:


### PR DESCRIPTION
BleakClient supports setting the timeout for direct connection to a known device address. Make that timeout configurable in `gshock_api`, the default (30s) one might be too short for scripting.