### PR TITLE
Time adjustment fixes

### DIFF
--- a/src/gshock_api/protocols/standard_protocol.py
+++ b/src/gshock_api/protocols/standard_protocol.py
@@ -150,6 +150,7 @@ class StandardProtocol(WatchProtocol):
             if isinstance(settings, dict) and isinstance(time_adj_res, dict):
                 val = time_adj_res.get("timeAdjustment")
                 settings["time_adjustment"] = str(val).lower() in ("true", "1")
+                settings["time_adjustment_minutes_after_hour"] = time_adj_res.get("minutesAfterHour")
         except Exception:
             pass
         return settings

--- a/src/gshock_api/protocols/standard_protocol.py
+++ b/src/gshock_api/protocols/standard_protocol.py
@@ -149,7 +149,7 @@ class StandardProtocol(WatchProtocol):
             time_adj_res = await message_dispatcher.TimeAdjustmentIO.request(connection)
             if isinstance(settings, dict) and isinstance(time_adj_res, dict):
                 val = time_adj_res.get("timeAdjustment")
-                settings["timeAdjustment"] = str(val).lower() in ("true", "1")
+                settings["time_adjustment"] = str(val).lower() in ("true", "1")
         except Exception:
             pass
         return settings

--- a/src/gshock_api/settings.py
+++ b/src/gshock_api/settings.py
@@ -13,6 +13,7 @@ class Settings:
     power_saving_mode: bool = False
     button_tone: bool = True
     time_adjustment: bool = True
+    time_adjustment_minutes_after_hour: int = 30
 
 # Instantiate the settings object using the typed dataclass
 settings: Settings = Settings()


### PR DESCRIPTION
There's an inconsistency between the settings name (in `settings.py`) and what is actually set by the code, so fix that.

Also add a settings for `minutes_after_hour`. I guess it's not common to set it but the `api_test.py` does and it took me a while to identify why time adjustment didn't happen.

(note: even after setting back minutes_after_hour to 30 it still doesn't happen at 1830 so I'm still investigating)