### PR TITLE
steps: also return raw payload for more parsing

### DIFF
--- a/src/gshock_api/iolib/step_counter_io.py
+++ b/src/gshock_api/iolib/step_counter_io.py
@@ -59,6 +59,7 @@ class StepCounterIOFunctional:
             hourly_steps=hourly_steps,
             daily_history=daily_history,
             current_day_steps=current_day_steps,
+            payload=payload,
         )
 
 

--- a/src/gshock_api/step_counter_data.py
+++ b/src/gshock_api/step_counter_data.py
@@ -11,6 +11,7 @@ class StepCounterData:
     hourly_steps: list[int | None] = field(default_factory=list)
     daily_history: list[int | None] = field(default_factory=list)
     current_day_steps: int | None = None
+    payload: bytes = None
 
     @classmethod
     def unavailable(cls) -> "StepCounterData":


### PR DESCRIPTION
Store the raw steps payload in the step counter data so more analysis can be done later (examples in the `casiosync.py` and `lifelog.py` scripts by @taviso