### PR TITLE
step_counter: fix payload timestamp decoding

### DIFF
--- a/src/gshock_api/iolib/step_counter_io.py
+++ b/src/gshock_api/iolib/step_counter_io.py
@@ -1,4 +1,5 @@
 import struct
+from datetime import datetime
 from typing import Final
 
 from gshock_api.cancelable_result import CancelableResult
@@ -24,6 +25,18 @@ class StepCounterIOFunctional:
 
     @staticmethod
     def parse(payload: bytes) -> StepCounterData | None:
+        def bcd(byte: int) -> int:
+            """Decode one packed-BCD byte."""
+            high, low = divmod(byte, 16)
+            if high > 9 or low > 9:
+                raise ValueError(f"invalid BCD byte 0x{byte:02x}")
+            return high * 10 + low
+
+        def decode_timestamp(data: bytes) -> datetime:
+            """Decode the six-byte timestamp at the start of a record."""
+            values = [bcd(byte) for byte in data[:6]]
+            return datetime(2000 + values[0], *values[1:])
+
         daily_history_offset = (
             StepCounterIOFunctional.HEADER_SIZE
             + StepCounterIOFunctional.HOURLY_SLOT_COUNT * StepCounterIOFunctional.HOURLY_SLOT_SIZE
@@ -52,10 +65,10 @@ class StepCounterIOFunctional:
         cur_val = struct.unpack_from("<I", payload, current_day_offset)[0]
         current_day_steps = None if cur_val == 0xFFFFFFFE else cur_val
 
+        timestamp = decode_timestamp(payload)
+
         return StepCounterData(
-            day_of_week=payload[1],
-            month=payload[2],
-            day_of_month=payload[3],
+            timestamp=timestamp,
             hourly_steps=hourly_steps,
             daily_history=daily_history,
             current_day_steps=current_day_steps,

--- a/src/gshock_api/step_counter_data.py
+++ b/src/gshock_api/step_counter_data.py
@@ -1,17 +1,16 @@
 from dataclasses import dataclass, field
+from datetime import datetime
 
 
 @dataclass
 class StepCounterData:
     """ABL-100WE life-log record representation."""
 
-    day_of_week: int = 0
-    month: int = 0
-    day_of_month: int = 0
+    timestamp: datetime = None
     hourly_steps: list[int | None] = field(default_factory=list)
     daily_history: list[int | None] = field(default_factory=list)
     current_day_steps: int | None = None
 
     @classmethod
     def unavailable(cls) -> "StepCounterData":
-        return cls(0, 0, 0, [], [], None)
+        return cls(None, [], [], None)


### PR DESCRIPTION
Another PR (sorry for the noise).

The initial parsing done by @f3z in #3 uses fields like `day_of_week` for the payload timestamp but it seems like it's a date and time in BCD.

Pick the functions used in lifelog.py by @taviso instead.

Example from a quick run:

```2026-08-31 12:32:44,597 gshock_api.logger INFO: Step count parsed: StepCounterData(timestamp=datetime.datetime(2026, 8, 31, 12, 32, 1), hourly_steps=[211, 464...```