### PR TITLE
Revert "step_counter: fix payload timestamp decoding"

### DIFF
--- a/src/gshock_api/iolib/step_counter_io.py
+++ b/src/gshock_api/iolib/step_counter_io.py
@@ -1,5 +1,4 @@
 import struct
-from datetime import datetime
 from typing import Final
 
 from gshock_api.cancelable_result import CancelableResult
@@ -25,18 +24,6 @@ class StepCounterIOFunctional:
 
     @staticmethod
     def parse(payload: bytes) -> StepCounterData | None:
-        def bcd(byte: int) -> int:
-            """Decode one packed-BCD byte."""
-            high, low = divmod(byte, 16)
-            if high > 9 or low > 9:
-                raise ValueError(f"invalid BCD byte 0x{byte:02x}")
-            return high * 10 + low
-
-        def decode_timestamp(data: bytes) -> datetime:
-            """Decode the six-byte timestamp at the start of a record."""
-            values = [bcd(byte) for byte in data[:6]]
-            return datetime(2000 + values[0], *values[1:])
-
         daily_history_offset = (
             StepCounterIOFunctional.HEADER_SIZE
             + StepCounterIOFunctional.HOURLY_SLOT_COUNT * StepCounterIOFunctional.HOURLY_SLOT_SIZE
@@ -65,10 +52,10 @@ class StepCounterIOFunctional:
         cur_val = struct.unpack_from("<I", payload, current_day_offset)[0]
         current_day_steps = None if cur_val == 0xFFFFFFFE else cur_val
 
-        timestamp = decode_timestamp(payload)
-
         return StepCounterData(
-            timestamp=timestamp,
+            day_of_week=payload[1],
+            month=payload[2],
+            day_of_month=payload[3],
             hourly_steps=hourly_steps,
             daily_history=daily_history,
             current_day_steps=current_day_steps,

--- a/src/gshock_api/model/step_counter_data.py
+++ b/src/gshock_api/model/step_counter_data.py
@@ -1,16 +1,17 @@
 from dataclasses import dataclass, field
-from datetime import datetime
 
 
 @dataclass
 class StepCounterData:
     """ABL-100WE life-log record representation."""
 
-    timestamp: datetime = None
+    day_of_week: int = 0
+    month: int = 0
+    day_of_month: int = 0
     hourly_steps: list[int | None] = field(default_factory=list)
     daily_history: list[int | None] = field(default_factory=list)
     current_day_steps: int | None = None
 
     @classmethod
     def unavailable(cls) -> "StepCounterData":
-        return cls(None, [], [], None)
+        return cls(0, 0, 0, [], [], None)


### PR DESCRIPTION
Reverts izivkov/gshock_api#12

Actually, I like the original way better. The model should be in a plain text form as much as possible. Timestamp is not. This makes it easy for the user of the library to see what exactly is being sent. Also, keeping is a timestamp instead of plain text fixes it to Python format and makes it harder to convert to other projects, like to Kotlin version of this library. Keep is plain and simple.

