### PR TITLE
Fix app-info registration write on never-registered watches

### DIFF
--- a/src/gshock_api/iolib/app_info_io.py
+++ b/src/gshock_api/iolib/app_info_io.py
@@ -75,7 +75,7 @@ class AppInfoIO:
                     raise RuntimeError("AppInfoIO.connection is not set")
                 for command in commands:
                     if isinstance(command, Write):
-                        await AppInfoIO.connection.write(command.handle, to_hex_string(command.data))
+                        await AppInfoIO.connection.write(command.handle, command.data)
 
             if AppInfoIO.result is None:
                 raise RuntimeError("AppInfoIO.result is not set")


### PR DESCRIPTION
On a watch that no app has registered yet (app info reply is all `FF`), the registration response never reaches the watch:

```
AppInfoIO.on_received: 0x22 FF FF FF FF FF FF FF FF FF FF 00
  File ".../gshock_api/connection.py", line 131, in write
    cmd_data: bytes = to_casio_cmd(data) if isinstance(data, str) else bytes(data)
  File ".../gshock_api/utils.py", line 20, in to_casio_cmd
    hex_arr: list[int] = [int(s, 16) for s in parts]
ValueError
gshock_api.exceptions.GShockConnectionError: Unable to send time to watch: ValueError
```

`on_received` passes `to_hex_string(command.data)` (`"0x22 34 88 ..."`, spaced and prefixed) to `Connection.write`, whose str path expects compact hex. Every other IO writer, including `send_to_watch` in the same file, passes `command.data` bytes directly, so do the same here.

Seen on a fresh F-B100W: before the change `get_app_info()` timed out on every connect; after it, the first connect writes the registration and later connects read it back (`0x22 34 88 F4 E5 D5 AF C8 29 E0 6D 02`).