### PR TITLE
Map F-B100W (module 3589) to ABL_100

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Overview
 This is a **Python API library** for G-Shock watches that support Bluetooth Low Energy (BLE) communication.
 
 G(M)W-5600, G(M)W-5000, GA-B2100, GA-B001-1AER, GST-B500, GST-B200, MSG-B100, 
-G-B001, GBD-H1000 (Partial support), MRG-B5000, GCW-B5000, GG-B100, ABL-100WE, 
+G-B001, GBD-H1000 (Partial support), MRG-B5000, GCW-B5000, GG-B100, ABL-100WE, F-B100W, 
 Edifice ECB-30, ECB-10, ECB-20, most Edifice watches, most Protrek models.
 
 It can perform the following tasks:

--- a/src/gshock_api/watch_info.py
+++ b/src/gshock_api/watch_info.py
@@ -25,6 +25,7 @@ class WatchModel(Enum):
     EQB = auto()
     ECB = auto()
     ABL_100 = auto()
+    F_B100 = auto()
     DW_H5600 = auto()
     GMW_BZ5000 = auto()
     GW_BX5600 = auto()
@@ -164,6 +165,16 @@ _MODEL_LIST: list[ModelInfo] = [
     ModelInfo(model=WatchModel.GST, hasAutoLight=False, hasReminders=True),
     ModelInfo(
         model=WatchModel.ABL_100,
+        hasAutoLight=False, hasReminders=False,
+        hasTemperature=False, hasBatteryLevel=False,
+        hasWorldCities=False, hasHomeTime=False,
+        hasStepCounter=True,
+        hasDateFormat=False,
+        weekLanguageSupported=False,
+        hasAppInfo=True,
+    ),
+    ModelInfo(
+        model=WatchModel.F_B100,
         hasAutoLight=False, hasReminders=False,
         hasTemperature=False, hasBatteryLevel=False,
         hasWorldCities=False, hasHomeTime=False,
@@ -406,7 +417,7 @@ EXACT_MODEL_MAP: dict[str, WatchModel] = {
     "PRW-B1000": WatchModel.GENERIC,
     "GMD-B300": WatchModel.GENERIC,
     "WS-B1000": WatchModel.GENERIC,
-    "F-B100W": WatchModel.ABL_100,  # module 3589, ABL-100 protocol family; advertises as "CASIO F-B100W"
+    "F-B100W": WatchModel.F_B100,  # module 3589; advertises as "CASIO F-B100W"
     "OCW-P3000": WatchModel.GENERIC,
 }
 

--- a/src/gshock_api/watch_info.py
+++ b/src/gshock_api/watch_info.py
@@ -406,7 +406,7 @@ EXACT_MODEL_MAP: dict[str, WatchModel] = {
     "PRW-B1000": WatchModel.GENERIC,
     "GMD-B300": WatchModel.GENERIC,
     "WS-B1000": WatchModel.GENERIC,
-    "F-B100W": WatchModel.GENERIC,
+    "F-B100W": WatchModel.ABL_100,  # module 3589, ABL-100 protocol family; advertises as "CASIO F-B100W"
     "OCW-P3000": WatchModel.GENERIC,
 }
 

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -264,7 +264,7 @@ class TestGShockFunctionalAPI(unittest.TestCase):
         self.assertIsInstance(watch_info.protocol, StandardProtocol)
 
         watch_info.set_name_and_model("CASIO F-B100W")
-        self.assertEqual(watch_info.model, WatchModel.ABL_100)
+        self.assertEqual(watch_info.model, WatchModel.F_B100)
         self.assertTrue(watch_info.hasStepCounter)
 
         watch_info.set_name_and_model("CASIO GW-B5600")

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -263,6 +263,10 @@ class TestGShockFunctionalAPI(unittest.TestCase):
         self.assertTrue(watch_info.hasStepCounter)
         self.assertIsInstance(watch_info.protocol, StandardProtocol)
 
+        watch_info.set_name_and_model("CASIO F-B100W")
+        self.assertEqual(watch_info.model, WatchModel.ABL_100)
+        self.assertTrue(watch_info.hasStepCounter)
+
         watch_info.set_name_and_model("CASIO GW-B5600")
         self.assertEqual(watch_info.model, WatchModel.GW)
         self.assertEqual(watch_info.worldCitiesCount, 6)


### PR DESCRIPTION
The F-B100W is in `EXACT_MODEL_MAP` as `GENERIC`, which turns the step counter off. It is an ABL-100 sibling (module 3589 vs 3565) and works with `ABL_100`.

Tested on an F-B100W-3AJF from macOS (bleak/CoreBluetooth). It advertises as `CASIO F-B100W`. With `ABL_100`:

- `get_watch_condition()` -> `{'battery_level_percent': 100, 'temperature': 25}`
- `get_app_info()` registers / reads back (needs #15 on a never-registered unit)
- `get_step_count(peek=True)` parses: `current_day_steps=0`, `timestamp=2026-09-06 04:56:01` (watch was still on factory JST), `daily_history=[231, 0, 0, 0, 0, 0, 0]`, no warnings
- `set_time()` works, both after a hold of the lower-left button and on a single lower-right press once registered

Not exercised: alarms, timer, settings, reminders.

One observation for anyone scripting this model: a lower-right-button session that ends without `set_time()` makes the watch flash `ERR`; ending with `set_time()` shows `OK`. Same thing @taviso noted in #3 for the ABL-100.

Also adds the assertion next to the ABL-100WE one in `test_watch_info_exact_lookup_and_protocols` and the model to the README list.